### PR TITLE
Update disqus.py

### DIFF
--- a/sphinxcontrib/disqus.py
+++ b/sphinxcontrib/disqus.py
@@ -12,7 +12,7 @@ import re
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from sphinx.application import ExtensionError, SphinxError
+from sphinx.errors import ExtensionError, SphinxError
 
 __author__ = '@Robpol86'
 __license__ = 'MIT'


### PR DESCRIPTION
Sphinx 1.6+ keeps errors in a separate module - https://github.com/sphinx-doc/sphinx/blob/master/sphinx/errors.py